### PR TITLE
fix(package.json): remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,11 +69,6 @@
     "sinon": "^4.3.0",
     "uglify-es": "^3.3.9"
   },
-  "peerDependencies": {
-    "pg": "^7.5.0",
-    "aws-sdk": "^2.197.0",
-    "pg-pool": "^2.0.3"
-  },
   "dependencies": {
     "axios": "^0.18.0",
     "google-protobuf": "^3.5.0",

--- a/src/events/pg.js
+++ b/src/events/pg.js
@@ -1,7 +1,7 @@
 const uuid4 = require('uuid4');
 const shimmer = require('shimmer');
-const pg = require('pg'); // eslint-disable-line import/no-unresolved
-const Pool = require('pg-pool'); // eslint-disable-line import/no-unresolved
+const pg = require('pg'); // eslint-disable-line import/no-unresolved import/no-extraneous-dependencies
+const Pool = require('pg-pool'); // eslint-disable-line import/no-unresolved import/no-extraneous-dependencies
 const sqlParser = require('node-sqlparser'); // eslint-disable-line import/no-unresolved
 const utils = require('../utils.js');
 const tracer = require('../tracer.js');

--- a/src/events/pg.js
+++ b/src/events/pg.js
@@ -1,8 +1,8 @@
 const uuid4 = require('uuid4');
 const shimmer = require('shimmer');
-const pg = require('pg');
-const Pool = require('pg-pool');
-const sqlParser = require('node-sqlparser');
+const pg = require('pg'); // eslint-disable-line import/no-unresolved
+const Pool = require('pg-pool'); // eslint-disable-line import/no-unresolved
+const sqlParser = require('node-sqlparser'); // eslint-disable-line import/no-unresolved
 const utils = require('../utils.js');
 const tracer = require('../tracer.js');
 const serverlessEvent = require('../proto/event_pb.js');

--- a/src/events/pg.js
+++ b/src/events/pg.js
@@ -1,8 +1,10 @@
 const uuid4 = require('uuid4');
 const shimmer = require('shimmer');
-const pg = require('pg'); // eslint-disable-line import/no-unresolved import/no-extraneous-dependencies
-const Pool = require('pg-pool'); // eslint-disable-line import/no-unresolved import/no-extraneous-dependencies
-const sqlParser = require('node-sqlparser'); // eslint-disable-line import/no-unresolved
+/* eslint-disable import/no-unresolved, import/no-extraneous-dependencies */
+const pg = require('pg');
+const Pool = require('pg-pool');
+const sqlParser = require('node-sqlparser');
+/* eslint-enable import/no-unresolved, import/no-extraneous-dependencies */
 const utils = require('../utils.js');
 const tracer = require('../tracer.js');
 const serverlessEvent = require('../proto/event_pb.js');


### PR DESCRIPTION
Removing the following messages on install:
```
npm WARN epsagon@0.0.0-development requires a peer of pg@^7.5.0 but none is installed. You must install peer dependencies yourself.
npm WARN epsagon@0.0.0-development requires a peer of aws-sdk@^2.197.0 but none is installed. You must install peer dependencies yourself.
npm WARN epsagon@0.0.0-development requires a peer of pg-pool@^2.0.3 but none is installed. You must install peer dependencies yourself.
```