### PR TITLE
fix(aws_sdk): tryRequire aws-sdk lib

### DIFF
--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -1,9 +1,9 @@
 /**
  * @fileoverview Handlers for the aws-sdk js library instrumantation.
  */
-const AWS = require('aws-sdk'); // eslint-disable-line import/no-extraneous-dependencies
 const md5 = require('md5');
 const uuid4 = require('uuid4');
+const tryRequire = require('try-require');
 const shimmer = require('shimmer');
 JSON.sortify = require('json.sortify');
 const utils = require('../utils.js');
@@ -13,6 +13,8 @@ const eventInterface = require('../event.js');
 const errorCode = require('../proto/error_code_pb.js');
 const { STEP_ID_NAME } = require('../consts.js');
 const resourceUtils = require('../resource_utils/sqs_utils.js');
+
+const AWS = tryRequire('aws-sdk');
 
 const s3EventCreator = {
     /**
@@ -748,7 +750,9 @@ module.exports = {
      * Initializes the aws-sdk tracer
      */
     init() {
-        shimmer.wrap(AWS.Request.prototype, 'send', AWSSDKWrapper);
-        shimmer.wrap(AWS.Request.prototype, 'promise', AWSSDKWrapper);
+        if (AWS) {
+            shimmer.wrap(AWS.Request.prototype, 'send', AWSSDKWrapper);
+            shimmer.wrap(AWS.Request.prototype, 'promise', AWSSDKWrapper);
+        }
     },
 };


### PR DESCRIPTION
to make aws-sdk lib not dependency
fixes: https://github.com/epsagon/serverless-plugin-epsagon/issues/21