### PR TITLE
fix(config.js): set metadata and SSL via envs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -9,8 +9,8 @@ const consts = require('./consts.js');
 const config = {
     token: process.env.EPSAGON_TOKEN || '',
     appName: process.env.EPSAGON_APP_NAME || 'Application',
-    metadataOnly: false,
-    useSSL: true,
+    metadataOnly: (process.env.EPSAGON_METADATA || '').toUpperCase() === 'TRUE',
+    useSSL: (process.env.EPSAGON_SSL || '').toUpperCase() === 'TRUE',
     traceCollectorURL: consts.TRACE_COLLECTOR_URL,
     isEpsagonDisabled: (process.env.DISABLE_EPSAGON || '').toUpperCase() === 'TRUE',
     /**

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ const config = {
     token: process.env.EPSAGON_TOKEN || '',
     appName: process.env.EPSAGON_APP_NAME || 'Application',
     metadataOnly: (process.env.EPSAGON_METADATA || '').toUpperCase() === 'TRUE',
-    useSSL: (process.env.EPSAGON_SSL || '').toUpperCase() === 'TRUE',
+    useSSL: (process.env.EPSAGON_SSL || 'TRUE').toUpperCase() === 'TRUE',
     traceCollectorURL: consts.TRACE_COLLECTOR_URL,
     isEpsagonDisabled: (process.env.DISABLE_EPSAGON || '').toUpperCase() === 'TRUE',
     /**


### PR DESCRIPTION
Setting EPSAGON_METADATA and EPSAGON_SSL similar to Python.