### PR TITLE
fix(http.js): support https

### DIFF
--- a/src/events/http.js
+++ b/src/events/http.js
@@ -5,6 +5,7 @@
 const uuid4 = require('uuid4');
 const shimmer = require('shimmer');
 const http = require('http');
+const https = require('https');
 const utils = require('../utils.js');
 const tracer = require('../tracer.js');
 const serverlessEvent = require('../proto/event_pb.js');
@@ -173,7 +174,6 @@ function httpWrapper(wrappedFunction) {
                 tracer.addException(err);
             });
 
-
             tracer.addEvent(awsEvent, responsePromise);
         } catch (error) {
             tracer.addException(error);
@@ -193,5 +193,6 @@ module.exports = {
      */
     init() {
         shimmer.wrap(http, 'request', httpWrapper);
+        shimmer.wrap(https, 'request', httpWrapper);
     },
 };

--- a/test/acceptance/run.sh
+++ b/test/acceptance/run.sh
@@ -29,6 +29,8 @@ build_num=$1
 result=0
 
 run_acceptance_test ${build_num} nodejs8.10 njs8
-run_acceptance_test ${build_num} nodejs6.10 njs6
+
+# nodejs6.10 is officially not supported anymore
+#run_acceptance_test ${build_num} nodejs6.10 njs6
 
 exit ${result}


### PR DESCRIPTION
🆙 
also removing nodejs 6.10 from acceptance
```
  An error occurred: SyncUnderscore3UnderscoreparamUnderscorenoUnderscorereturnLambdaFunction - The runtime parameter of nodejs6.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs8.10) while creating or updating functions. (Service: AWSLambdaInternal; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: 42ee903d-7651-11e9-aebb-c5346f4d655f).
```