### PR TITLE
fix(tracer): give promises chance to resolve

### DIFF
--- a/src/tracer.js
+++ b/src/tracer.js
@@ -266,26 +266,32 @@ module.exports.sendTraceSync = function sendTraceSync() {
     utils.debugLog('Sending trace sync');
     const tracerObj = module.exports.getTrace();
 
-    tracerObj.pendingEvents.forEach((promise, event) => {
-        if (promise.isPending()) {
-            // Consider changing to report a different type of error. Maybe a new error code
-            // describing an unknown operation state
-            if (!event.getId()) {
-                event.setId(uuid4());
+    // we give the promises a chance to update value to resolved.
+    return Promise.race([
+        Promise.all(tracerObj.pendingEvents.values()),
+        Promise.resolve(),
+    ]).then(() => {
+        tracerObj.pendingEvents.forEach((promise, event) => {
+            if (promise.isPending()) {
+                // Consider changing to report a different type of error. Maybe a new error code
+                // describing an unknown operation state
+                if (!event.getId()) {
+                    event.setId(uuid4());
+                }
+                if (event.getErrorCode() === errorCode.ErrorCode.OK) {
+                    eventInterface.setException(
+                        event,
+                        Error('Operation not completed because of premature Lambda exit')
+                    );
+                }
+                if (event.getDuration() === 0) {
+                    event.setDuration(utils.createDurationTimestamp(event.getStartTime() * 1000));
+                }
             }
-            if (event.getErrorCode() === errorCode.ErrorCode.OK) {
-                eventInterface.setException(
-                    event,
-                    Error('Operation not completed because of premature Lambda exit')
-                );
-            }
-            if (event.getDuration() === 0) {
-                event.setDuration(utils.createDurationTimestamp(event.getStartTime() * 1000));
-            }
-        }
-    });
+        });
 
-    return sendCurrentTrace(traceObject => module.exports.postTrace(traceObject));
+        return sendCurrentTrace(traceObject => module.exports.postTrace(traceObject));
+    });
 };
 
 /**

--- a/test/unit_tests/test_tracer.js
+++ b/test/unit_tests/test_tracer.js
@@ -447,10 +447,11 @@ describe('sendTraceSync function tests', () => {
         this.postStub.restore();
     });
 
-    it('sendTraceSync: post when no events pending', () => {
-        tracer.sendTraceSync();
-        expect(this.postStub.calledOnce).to.be.true;
-    });
+    it('sendTraceSync: post when no events pending', () => (
+        tracer.sendTraceSync().then(() => {
+            expect(this.postStub.calledOnce).to.be.true;
+        })
+    ));
 
     it('sendTraceSync: post event if not all events resolved', () => {
         const eventToAdd = new serverlessEvent.Event();
@@ -467,10 +468,10 @@ describe('sendTraceSync function tests', () => {
         });
 
         tracer.addEvent(eventToAdd, stubPromise);
-        tracer.sendTraceSync();
-
-        expect(this.postStub.calledOnce).to.be.true;
-        shouldPromiseEnd = true;
+        return tracer.sendTraceSync().then(() => {
+            expect(this.postStub.calledOnce).to.be.true;
+            shouldPromiseEnd = true;
+        });
     });
 
     it('sendTraceSync: post even if event rejected', () => {
@@ -478,8 +479,9 @@ describe('sendTraceSync function tests', () => {
         const stubPromise = Promise.reject(new Error('failed'));
         tracer.addEvent(eventToAdd, stubPromise);
 
-        tracer.sendTraceSync();
-        expect(this.postStub.calledOnce).to.be.true;
+        return tracer.sendTraceSync().then(() => {
+            expect(this.postStub.calledOnce).to.be.true;
+        });
     });
 
     it('sendTraceSync: send even with for more then 1 event pending', () => {
@@ -512,10 +514,11 @@ describe('sendTraceSync function tests', () => {
         });
 
         tracer.addEvent(eventToAdd2, stubPromise2);
-        tracer.sendTraceSync();
-        expect(this.postStub.calledOnce).to.be.true;
-        shouldPromiseEnd1 = true;
-        shouldPromiseEnd2 = true;
+        return tracer.sendTraceSync().then(() => {
+            expect(this.postStub.calledOnce).to.be.true;
+            shouldPromiseEnd1 = true;
+            shouldPromiseEnd2 = true;
+        });
     });
 
     it('sendTraceSync: there is more then 1 event and some rejects', () => {
@@ -539,10 +542,10 @@ describe('sendTraceSync function tests', () => {
 
         tracer.addEvent(eventToAdd2, stubPromise2);
 
-        tracer.sendTraceSync();
-
-        expect(this.postStub.calledOnce).to.be.true;
-        shouldPromiseEnd1 = true;
+        return tracer.sendTraceSync().then(() => {
+            expect(this.postStub.calledOnce).to.be.true;
+            shouldPromiseEnd1 = true;
+        });
     });
 
     it('sendTraceSync: send too big trace', () => {
@@ -592,9 +595,10 @@ describe('sendTraceSync function tests', () => {
 
         tracer.addEvent(eventToAdd2, stubPromise2);
 
-        tracer.sendTraceSync();
-        expect(this.postStub.calledOnce).to.be.true;
-        shouldPromiseEnd1 = true;
-        shouldPromiseEnd2 = true;
+        return tracer.sendTraceSync().then(() => {
+            expect(this.postStub.calledOnce).to.be.true;
+            shouldPromiseEnd1 = true;
+            shouldPromiseEnd2 = true;
+        });
     });
 });


### PR DESCRIPTION
Until now, if the last operation remaining in the event loop was our handling of an event, the `promise.isPending()` wouldn't get a chance to update and we would mark the operation as a timeout. This PR attempts to resolve it by adding an async action of race with a resolved promise before evaluating the value of `promise.isPending()` on the events. This should let the pending flag the free tick it needs to update.