### PR TITLE
Revert "fix(tracer): give promises chance to resolve"

### DIFF
--- a/test/unit_tests/test_tracer.js
+++ b/test/unit_tests/test_tracer.js
@@ -447,11 +447,10 @@ describe('sendTraceSync function tests', () => {
         this.postStub.restore();
     });
 
-    it('sendTraceSync: post when no events pending', () => (
-        tracer.sendTraceSync().then(() => {
-            expect(this.postStub.calledOnce).to.be.true;
-        })
-    ));
+    it('sendTraceSync: post when no events pending', () => {
+        tracer.sendTraceSync();
+        expect(this.postStub.calledOnce).to.be.true;
+    });
 
     it('sendTraceSync: post event if not all events resolved', () => {
         const eventToAdd = new serverlessEvent.Event();
@@ -468,10 +467,10 @@ describe('sendTraceSync function tests', () => {
         });
 
         tracer.addEvent(eventToAdd, stubPromise);
-        return tracer.sendTraceSync().then(() => {
-            expect(this.postStub.calledOnce).to.be.true;
-            shouldPromiseEnd = true;
-        });
+        tracer.sendTraceSync();
+
+        expect(this.postStub.calledOnce).to.be.true;
+        shouldPromiseEnd = true;
     });
 
     it('sendTraceSync: post even if event rejected', () => {
@@ -479,9 +478,8 @@ describe('sendTraceSync function tests', () => {
         const stubPromise = Promise.reject(new Error('failed'));
         tracer.addEvent(eventToAdd, stubPromise);
 
-        return tracer.sendTraceSync().then(() => {
-            expect(this.postStub.calledOnce).to.be.true;
-        });
+        tracer.sendTraceSync();
+        expect(this.postStub.calledOnce).to.be.true;
     });
 
     it('sendTraceSync: send even with for more then 1 event pending', () => {
@@ -514,11 +512,10 @@ describe('sendTraceSync function tests', () => {
         });
 
         tracer.addEvent(eventToAdd2, stubPromise2);
-        return tracer.sendTraceSync().then(() => {
-            expect(this.postStub.calledOnce).to.be.true;
-            shouldPromiseEnd1 = true;
-            shouldPromiseEnd2 = true;
-        });
+        tracer.sendTraceSync();
+        expect(this.postStub.calledOnce).to.be.true;
+        shouldPromiseEnd1 = true;
+        shouldPromiseEnd2 = true;
     });
 
     it('sendTraceSync: there is more then 1 event and some rejects', () => {
@@ -542,10 +539,10 @@ describe('sendTraceSync function tests', () => {
 
         tracer.addEvent(eventToAdd2, stubPromise2);
 
-        return tracer.sendTraceSync().then(() => {
-            expect(this.postStub.calledOnce).to.be.true;
-            shouldPromiseEnd1 = true;
-        });
+        tracer.sendTraceSync();
+
+        expect(this.postStub.calledOnce).to.be.true;
+        shouldPromiseEnd1 = true;
     });
 
     it('sendTraceSync: send too big trace', () => {
@@ -595,10 +592,9 @@ describe('sendTraceSync function tests', () => {
 
         tracer.addEvent(eventToAdd2, stubPromise2);
 
-        return tracer.sendTraceSync().then(() => {
-            expect(this.postStub.calledOnce).to.be.true;
-            shouldPromiseEnd1 = true;
-            shouldPromiseEnd2 = true;
-        });
+        tracer.sendTraceSync();
+        expect(this.postStub.calledOnce).to.be.true;
+        shouldPromiseEnd1 = true;
+        shouldPromiseEnd2 = true;
     });
 });


### PR DESCRIPTION
Reverts epsagon/epsagon-node#96

```

  1) Lambda Wrapper
       behaves correctly on sync_2_param_simple_return:
      AssertionError: expected '{"errorMessage":"2019-05-27T18:46:36.925Z 99b8b2d5-c119-4994-8aab-7ce6e7e747e8 Task timed out after 6.01 seconds"}' to equal 'null'
      + expected - actual
      -{"errorMessage":"2019-05-27T18:46:36.925Z 99b8b2d5-c119-4994-8aab-7ce6e7e747e8 Task timed out after 6.01 seconds"}
      +null
      
      at Object.basicNoReturn (test/acceptance/acceptance.js:84:33)
      at <anonymous>
      at process._tickDomainCallback (internal/process/next_tick.js:228:7)

```