### PR TITLE
feat(openwhisk): track API host and namespace for OpenWhisk invocations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -988,7 +988,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -2079,7 +2080,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "denque": {
       "version": "1.4.0",
@@ -2874,7 +2876,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "eyes": {
       "version": "0.1.8",
@@ -4059,7 +4062,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "issue-parser": {
       "version": "4.0.0",
@@ -4115,7 +4119,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "jshint": {
       "version": "2.9.6",
@@ -4668,13 +4673,15 @@
       "version": "1.36.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
       "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "mime-types": {
       "version": "2.1.20",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "dev": true,
+      "optional": true,
       "requires": {
         "mime-db": "~1.36.0"
       }
@@ -10818,7 +10825,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/src/wrappers/openwhisk.js
+++ b/src/wrappers/openwhisk.js
@@ -35,6 +35,8 @@ function createRunner(functionName, originalParams) {
     runner.setResource(runnerResource);
     eventInterface.addToMetadata(runner, {
         activation_id: process.env['__OW_ACTIVATION_ID'], // eslint-disable-line dot-notation
+        api_host: process.env['__OW_API_HOST'], // eslint-disable-line dot-notation
+        namespace: process.env['__OW_NAMESPACE'], // eslint-disable-line dot-notation
         params: originalParams,
     });
     return runner;


### PR DESCRIPTION
Tracking the API host  can be useful for applications that are using multiple OpenWhisk instances, such as Adobe I/O Runtime and IBM BlueMix Functions together. Tracking the namespace is even more useful, because running one application across multiple namespaces (think user accounts) in the same instance is very common.