### PR TITLE
fix(trace): identifiying done events better

### DIFF
--- a/src/events/amazon_dax_client.js
+++ b/src/events/amazon_dax_client.js
@@ -93,8 +93,6 @@ function DAXWrapper(wrappedFunction) {
                         resolve();
                     }
                 });
-            }).catch((err) => {
-                tracer.addException(err);
             });
             tracer.addEvent(daxEvent, responsePromise);
         } catch (error) {

--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -751,8 +751,6 @@ function AWSSDKWrapper(wrappedFunction) {
                         resolve();
                     }
                 });
-            }).catch((err) => {
-                tracer.addException(err);
             });
 
             tracer.addEvent(awsEvent, responsePromise);

--- a/src/events/sql.js
+++ b/src/events/sql.js
@@ -109,8 +109,6 @@ module.exports.wrapSqlQuery = function wrapSqlQuery(queryString, params, callbac
                     callback(err, res, fields);
                 }
             };
-        }).catch((err) => {
-            tracer.addException(err);
         });
 
         tracer.addEvent(dbapiEvent, responsePromise);

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -69,7 +69,9 @@ module.exports.addEvent = function addEvent(event, promise) {
     if (promise !== undefined) {
         tracerObj.pendingEvents.set(
             event,
-            utils.makeQueryablePromise(utils.reflectPromise(promise))
+            utils.makeQueryablePromise(promise.catch((err) => {
+                module.exports.addException(err);
+            }))
         );
     }
 
@@ -78,10 +80,11 @@ module.exports.addEvent = function addEvent(event, promise) {
 
 /**
  * Adds an exception to the tracer
- * @param {Error} error The error object describing the exception
+ * @param {Error} userError The error object describing the exception
  * @param {Object} additionalData Additional data to send with the error. A map of <string: string>
  */
-module.exports.addException = function addException(error, additionalData) {
+module.exports.addException = function addException(userError, additionalData) {
+    const error = userError || new Error();
     const raisedException = new exception.Exception([
         error.name,
         error.message,

--- a/test/unit_tests/test_tracer.js
+++ b/test/unit_tests/test_tracer.js
@@ -26,7 +26,7 @@ describe('tracer restart tests - if these fail the others will too', () => {
         tracer.getTrace = tracerObj.get;
         tracer.initTrace({ token: 'token', appName: 'app' });
         tracer.addEvent(new serverlessEvent.Event());
-        tracer.addException(Error('test error'));
+        tracer.addException(new Error('test error'));
         tracer.restart();
         tracer.addRunner(new serverlessEvent.Event());
         expect(tracerObj.get().trace.getEventList().length).to.equal(1);


### PR DESCRIPTION
when we reflected the promise using `then`, there were cases where the `isPending()` field returned a non-updated value. Using only `catch` should fix that.