### PR TITLE
fix(aws_sdk.py): fix sqs params and missing http headers

### DIFF
--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -173,6 +173,11 @@ const SQSEventCreator = {
                 'Message Body': entry.MessageBody,
             });
         }
+        if ('MessageAttributes' in entry) {
+            eventInterface.addToMetadata(event, {}, {
+                'Message Attributes': entry.MessageAttributes,
+            });
+        }
     },
 
     /**

--- a/src/events/http.js
+++ b/src/events/http.js
@@ -135,6 +135,7 @@ function httpWrapper(wrappedFunction) {
             const url = `${protocol}://${hostname}${pathname}`;
             const fullURL = `${url}${path}`;
             httpEvent.setResource(resource);
+
             eventInterface.addToMetadata(httpEvent,
                 { url }, {
                     path,
@@ -157,6 +158,16 @@ function httpWrapper(wrappedFunction) {
                 eventInterface.addToMetadata(httpEvent, metadataFields, {
                     response_headers: res.headers,
                 });
+
+                // Override request headers if they are present here. In some libs they are not
+                // available on `options.headers`
+                // eslint-disable-next-line no-underscore-dangle
+                if (res.req && res.req._headers) {
+                    eventInterface.addToMetadata(httpEvent, metadataFields, {
+                        // eslint-disable-next-line no-underscore-dangle
+                        request_headers: res.req._headers,
+                    });
+                }
 
                 if ('x-amzn-requestid' in res.headers) {
                     // This is a request to AWS API Gateway

--- a/src/triggers/aws_lambda.js
+++ b/src/triggers/aws_lambda.js
@@ -110,7 +110,8 @@ function createSQSTrigger(event, trigger) {
     resource.setOperation('ReceiveMessage');
     eventInterface.addToMetadata(trigger, {
         'MD5 Of Message Body': event.Records[0].md5OfBody,
-        'Message Attributes': event.Records[0].attributes,
+        Attributes: event.Records[0].attributes,
+        'Message Attributes': event.Records[0].messageAttributes,
     }, {
         'Message Body': event.Records[0].body,
     });


### PR DESCRIPTION
1. in SQS trigger we collect attributes and message attributes.
2. In SQS operation we collect message attributes.
3. In HTTP event we will re-collect request headers again.