### PR TITLE
fix(lambda.js): validate source is not null

### DIFF
--- a/src/triggers/aws_lambda.js
+++ b/src/triggers/aws_lambda.js
@@ -257,7 +257,7 @@ module.exports.createFromEvent = function createFromEvent(event, context) {
             if ('eventSource' in event.Records[0]) {
                 triggerService = event.Records[0].eventSource.split(':').pop();
             }
-        } else if ('source' in event) {
+        } else if ('source' in event && event.source) {
             triggerService = event.source.split('.').pop();
         } else if (('requestContext' in event) && ('elb' in event.requestContext)) {
             triggerService = 'elastic_load_balancer';

--- a/src/wrappers/lambda.js
+++ b/src/wrappers/lambda.js
@@ -65,7 +65,7 @@ function baseLambdaWrapper(
 
             tracer.addEvent(trigger);
         } catch (err) {
-            tracer.addException(err, { event: JSON.stringify(originalEvent) });
+            utils.debugLog(`Error parsing trigger: ${err}`);
         }
 
         const startTime = Date.now();

--- a/src/wrappers/lambda.js
+++ b/src/wrappers/lambda.js
@@ -65,7 +65,7 @@ function baseLambdaWrapper(
 
             tracer.addEvent(trigger);
         } catch (err) {
-            utils.debugLog(`Error parsing trigger: ${err}`);
+            utils.debugLog(`Error parsing trigger: ${err}, Event: ${JSON.stringify(originalEvent)}`);
         }
 
         const startTime = Date.now();

--- a/test/unit_tests/wrappers/test_lambda.js
+++ b/test/unit_tests/wrappers/test_lambda.js
@@ -183,7 +183,6 @@ describe('lambdaWrapper tests', () => {
             expect(this.createFromEventStub.callCount).to.equal(1);
             expect(this.createFromEventStub.calledWith({}));
             expect(this.addEventStub.callCount).to.equal(0);
-            expect(this.addExceptionStub.callCount).to.equal(1);
             expect(this.sendTraceStub.callCount).to.equal(1);
             expect(this.stubFunction.callCount).to.equal(1);
             expect(this.callbackStub.callCount).to.equal(1);
@@ -588,7 +587,6 @@ describe('stepLambdaWrapper tests', () => {
             expect(this.createFromEventStub.callCount).to.equal(1);
             expect(this.createFromEventStub.calledWith({}));
             expect(this.addEventStub.callCount).to.equal(0);
-            expect(this.addExceptionStub.callCount).to.equal(1);
             expect(this.sendTraceStub.callCount).to.equal(1);
             expect(this.stubFunction.callCount).to.equal(1);
             expect(this.callbackStub.callCount).to.equal(1);


### PR DESCRIPTION
We had a use case where there was a "source" but it was null