### PR TITLE
feat(config): ignoredKeys supports regular expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,16 @@ function handler(event, context, callback) {
 
 You can pass a list of sensitive properties and they will be filtered out:
 
-```node
+```javascript
 epsagon.init({
     token: 'my-secret-token',
     appName: 'my-app-name',
     metadataOnly: false, // Optional, send more trace data
-    ignoredKeys: ['password', ...]
+    ignoredKeys: ['password', /.*_token$/ , …]
 });
 ```
+
+The `ignoredKeys` property can contain strings (will perform a lose match, so that `First Name` also matches `first_name`), regular expressions, and predicate functions.
 
 Alternatively you can pass a comma-separated list of sensitive keys using 
 the `EPSAGON_IGNORED_KEYS` environment variable to get the same effect.

--- a/src/config.js
+++ b/src/config.js
@@ -67,7 +67,7 @@ if (process.env.EPSAGON_URLS_TO_IGNORE) {
 }
 
 if (process.env.EPSAGON_IGNORED_KEYS) {
-    config.ignoredKeys = process.env.EPSAGON_IGNORED_KEYS.split(',').map(module.exports.processIgnoredKey);
+    config.ignoredKeys = process.env.EPSAGON_IGNORED_KEYS.split(',');
 }
 
 /**
@@ -119,7 +119,7 @@ module.exports.setConfig = function setConfig(configData) {
     }
 
     if (configData.ignoredKeys) {
-        config.ignoredKeys = configData.ignoredKeys.map(module.exports.processIgnoredKey);
+        config.ignoredKeys = configData.ignoredKeys;
     }
 
     if (configData.sampleRate !== null && config.sampleRate !== undefined) {

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -303,7 +303,7 @@ module.exports.filterTrace = function filterTrace(traceObject, ignoredKeys) {
     function isNotIgnored(key) {
         for (let i = 0; i < ignoredKeys.length; i += 1) {
             const predicate = ignoredKeys[i];
-            if (typeof predicate === 'string' && 
+            if (typeof predicate === 'string' &&
             config.processIgnoredKey(predicate) === config.processIgnoredKey(key)) {
                 return false;
             }

--- a/test/unit_tests/test_config.js
+++ b/test/unit_tests/test_config.js
@@ -75,10 +75,4 @@ describe('tracer config tests', () => {
         config.setConfig({ httpErrorStatusCode });
         expect(config.HTTP_ERR_CODE).to.be.equal(httpErrorStatusCode);
     });
-
-    it('setConfig: set ignoredKeys', () => {
-        config.setConfig({ ignoredKeys: ['studentId', '_password', 'first_name', 'last name'] });
-        const expected = ['studentid', 'password', 'firstname', 'lastname'];
-        expect(config.getConfig().ignoredKeys).to.eql(expected);
-    });
 });

--- a/test/unit_tests/test_tracer.js
+++ b/test/unit_tests/test_tracer.js
@@ -42,13 +42,14 @@ describe('filter keys function', () => {
             events: [{
                 resource: {
                     metadata: {
+                        employeeId: 'personal',
                         studentId: 'personal',
                         message: 'not-personal',
                     },
                 },
             }],
         };
-        const ignoredKeys = ['studentid'];
+        const ignoredKeys = ['studentid', /.*Id$/];
         const filtered = tracer.filterTrace(traceObject, ignoredKeys);
         const expected = {
             events: [{


### PR DESCRIPTION
Simple string-based comparison is often not enough, and this change allows pattern-based surpression of keys

partial fix of #127
