### PR TITLE
openwhisk: various fixes

### DIFF
--- a/src/events/openwhisk.js
+++ b/src/events/openwhisk.js
@@ -31,6 +31,9 @@ function openWhiskWrapper(wrappedFunction) {
         ]);
 
         invokeEvent.setResource(resource);
+        eventInterface.addToMetadata(invokeEvent, {
+            params: options.params,
+        });
         let request;
         let response;
         if (options.result) {

--- a/src/events/openwhisk.js
+++ b/src/events/openwhisk.js
@@ -33,7 +33,7 @@ function openWhiskWrapper(wrappedFunction) {
         invokeEvent.setResource(resource);
 
         const request = wrappedFunction.apply(this, [options, callback]);
-        const responsePromise = new Promise((resolve) => {
+        const responsePromise = new Promise((resolve, reject) => {
             request.then((res) => {
                 eventInterface.addToMetadata(
                     invokeEvent,
@@ -44,6 +44,9 @@ function openWhiskWrapper(wrappedFunction) {
                 );
                 invokeEvent.setDuration(utils.createDurationTimestamp(startTime));
                 resolve();
+            }).catch((err) => {
+                eventInterface.setException(invokeEvent, err);
+                reject(err);
             });
         });
 

--- a/src/events/openwhisk.js
+++ b/src/events/openwhisk.js
@@ -31,15 +31,37 @@ function openWhiskWrapper(wrappedFunction) {
         ]);
 
         invokeEvent.setResource(resource);
+        let request;
+        let response;
+        if (options.result) {
+            // action.invoke would return directly `response.result` so we would loose some
+            // of the information from the response.
+            const opts = {
+                ...options,
+                result: false,
+            };
+            request = wrappedFunction.apply(this, [opts, callback]);
+            // ensure we return the originally requested form
+            response = request.then(res => res.response.result);
+        } else {
+            request = wrappedFunction.apply(this, [options, callback]);
+            response = request;
+        }
 
-        const request = wrappedFunction.apply(this, [options, callback]);
         const responsePromise = new Promise((resolve, reject) => {
             request.then((res) => {
+                let resp = res.response;
+                if (resp && resp.result && resp.result.body && resp.result.body.length > 100) {
+                    // create copy so we can trim the long response body
+                    resp = Object.assign({}, resp);
+                    resp.result = Object.assign({}, resp.result);
+                    resp.result.body = `${resp.result.body.substring(0, 100)}...(truncated)`;
+                }
                 eventInterface.addToMetadata(
                     invokeEvent,
                     {
                         activation_id: res.activationId,
-                        response: res.response,
+                        response: resp,
                     }
                 );
                 invokeEvent.setDuration(utils.createDurationTimestamp(startTime));
@@ -51,7 +73,7 @@ function openWhiskWrapper(wrappedFunction) {
         });
 
         tracer.addEvent(invokeEvent, responsePromise);
-        return request;
+        return response;
     };
 }
 

--- a/src/events/openwhisk.js
+++ b/src/events/openwhisk.js
@@ -60,8 +60,14 @@ function openWhiskWrapper(wrappedFunction) {
                     resp.result = Object.assign({}, resp.result);
                     resp.result.body = `${resp.result.body.substring(0, 100)}...(truncated)`;
                 }
+                const brief = {
+                    activation_id: res.activationId,
+                    status: resp.status,
+                    result_statusCode: resp.result && resp.result.statusCode,
+                };
                 eventInterface.addToMetadata(
                     invokeEvent,
+                    brief,
                     {
                         activation_id: res.activationId,
                         response: resp,

--- a/src/events/openwhisk.js
+++ b/src/events/openwhisk.js
@@ -51,7 +51,7 @@ function openWhiskWrapper(wrappedFunction) {
             response = request;
         }
 
-        const responsePromise = new Promise((resolve, reject) => {
+        const responsePromise = new Promise((resolve) => {
             request.then((res) => {
                 let resp = res.response;
                 if (resp && resp.result && resp.result.body && resp.result.body.length > 100) {
@@ -68,10 +68,10 @@ function openWhiskWrapper(wrappedFunction) {
                     }
                 );
                 invokeEvent.setDuration(utils.createDurationTimestamp(startTime));
-                resolve();
             }).catch((err) => {
                 eventInterface.setException(invokeEvent, err);
-                reject(err);
+            }).finally(() => {
+                resolve();
             });
         });
 


### PR DESCRIPTION
- fixes #221

The problem was, that the tracer that receives the `responsePromise` would never continue, because the `responsePromise` would never resolve or reject in case of an error by the `request` promise.

- fixes #223 

actions invoked with `result:true` were not returning the entire response, so the response was not properly recorded.

- fixes #224 

also added the params of the actions to be invoked