### PR TITLE
feat(config): adding sendTimeout option to config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,12 @@ module.exports.processIgnoredKey = function processIgnoredKey(key) {
         .replace(/\s/g, '');
 };
 
+
+/**
+ * The default sendTimeout to send for send operations (both sync and async)
+ */
+const DEFAULT_TIMEOUT_SEC = 0.2;
+
 /**
  * configuration singleton. preconfigured with default values.
  */
@@ -32,6 +38,7 @@ const config = {
     urlPatternsToIgnore: [],
     internalSampleRate: 1,
     sendOnlyErrors: (process.env.EPSAGON_SEND_TRACE_ON_ERROR || '').toUpperCase() === 'TRUE',
+    sendTimeout: (Number(process.env.EPSAGON_SEND_TIMEOUT_SEC) || DEFAULT_TIMEOUT_SEC) * 1000.0,
     /**
      * get isEpsagonPatchDisabled
      * @return {boolean} True if DISABLE_EPSAGON or DISABLE_EPSAGON_PATCH are set to TRUE, false
@@ -141,5 +148,9 @@ module.exports.setConfig = function setConfig(configData) {
 
     if (configData.sampleRate !== null && config.sampleRate !== undefined) {
         config.sampleRate = configData.sampleRate;
+    }
+
+    if (Number(configData.sendTimeout)) { // we do not allow 0 as a timeout
+        config.sendTimeout = Number(configData.sendTimeout);
     }
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,6 +11,7 @@ declare module 'epsagon' {
     isEpsagonDisabled?: boolean
     urlPatternsToIgnore?: string[]
     sendOnlyErrors?: boolean
+    sendTimeout?: number
   }): void
   export function label(key: string, value: string): void
   export function setError(error: Error): void

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -52,17 +52,10 @@ module.exports.createTracer = function createTracer() {
 };
 
 /**
- * The timeout to send for send operations (both sync and async)
- */
-const timeoutEnv = (process.env.EPSAGON_SEND_TIMEOUT_SEC || 0) * 1000.0;
-const timeoutGraceTimeMs = 200;
-const sendTimeoutMilliseconds = timeoutEnv || timeoutGraceTimeMs;
-
-/**
  * Session for the post requests to the collector
  */
 const session = axios.create({
-    timeout: sendTimeoutMilliseconds,
+    sendTimeout: config.getConfig().sendTimeout,
     httpAgent: new http.Agent({ keepAlive: true }),
     httpsAgent: new https.Agent({ keepAlive: true }),
 });
@@ -403,7 +396,10 @@ module.exports.postTrace = function postTrace(traceObject) {
     return session.post(
         config.getConfig().traceCollectorURL,
         filteredTrace,
-        { headers: { Authorization: `Bearer ${config.getConfig().token}` } }
+        {
+            headers: { Authorization: `Bearer ${config.getConfig().token}` },
+            timeout: config.getConfig().sendTimeout,
+        }
     ).then((res) => {
         utils.debugLog('Trace posted!');
         return res;

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -55,7 +55,7 @@ module.exports.createTracer = function createTracer() {
  * Session for the post requests to the collector
  */
 const session = axios.create({
-    sendTimeout: config.getConfig().sendTimeout,
+    timeout: config.getConfig().sendTimeout,
     httpAgent: new http.Agent({ keepAlive: true }),
     httpsAgent: new https.Agent({ keepAlive: true }),
 });

--- a/test/unit_tests/test_config.js
+++ b/test/unit_tests/test_config.js
@@ -81,5 +81,16 @@ describe('tracer config tests', () => {
         const sendTimeout = 1000;
         config.setConfig({ sendTimeout });
         expect(config.getConfig().sendTimeout).to.be.equal(sendTimeout);
+
+        const sendTimeoutString = '1000';
+        config.setConfig({ sendTimeout: sendTimeoutString });
+        expect(config.getConfig().sendTimeout).to.be.equal(Number(sendTimeoutString));
+
+        const invalidSendTimeoutStrings = ['1200.1.1', 'affewfew', '4.4.a', '234a', '', null, undefined, 0];
+        invalidSendTimeoutStrings.forEach((invalidSendTimeoutString) => {
+            config.setConfig({ sendTimeout: invalidSendTimeoutString });
+            // checking the old value did not change
+            expect(config.getConfig().sendTimeout).to.be.equal(Number(sendTimeoutString));
+        });
     });
 });

--- a/test/unit_tests/test_config.js
+++ b/test/unit_tests/test_config.js
@@ -11,6 +11,7 @@ describe('tracer config tests', () => {
         useSSL: true,
         traceCollectorURL: consts.TRACE_COLLECTOR_URL,
         ignoredKeys: [],
+        sendTimeout: 200,
     };
 
 
@@ -74,5 +75,11 @@ describe('tracer config tests', () => {
         const httpErrorStatusCode = 42;
         config.setConfig({ httpErrorStatusCode });
         expect(config.HTTP_ERR_CODE).to.be.equal(httpErrorStatusCode);
+    });
+
+    it('setConfig: set custom sendTimeout', () => {
+        const sendTimeout = 1000;
+        config.setConfig({ sendTimeout });
+        expect(config.getConfig().sendTimeout).to.be.equal(sendTimeout);
     });
 });


### PR DESCRIPTION
This PR adds the `sendTimeout` config option. now the send timeout of the tracer can be configured via `epsagon.init` and not just via an environment variable