### PR TITLE
fix(http.js): fix epsagon trace extraction

### DIFF
--- a/src/events/http.js
+++ b/src/events/http.js
@@ -202,10 +202,6 @@ function httpWrapper(wrappedFunction) {
                     request_body: body,
                 });
 
-            eventInterface.addToMetadata(httpEvent, {
-                http_trace_id: traceId,
-            });
-
             const patchedCallback = (res) => {
                 let metadataFields = {};
                 if ('x-powered-by' in res.headers) {


### PR DESCRIPTION
Accidentally, the trace ID was added twice. The second time it included only a part of the full trace.