### PR TITLE
fix(ignored-keys): recursively searching in JSON strings

### DIFF
--- a/test/unit_tests/test_tracer.js
+++ b/test/unit_tests/test_tracer.js
@@ -100,6 +100,33 @@ describe('filter keys function', () => {
 
         expect(filtered).to.deep.equal(expected);
     });
+
+    it('filterTrace: filter recursively in strings', () => {
+        const traceObject = {
+            events: [{
+                resource: {
+                    metadata: {
+                        field: JSON.stringify({
+                            studentId: 'personal',
+                            message: 'not-personal',
+                        }),
+                        nonFiltered: 'studentid',
+                    },
+                },
+            }],
+        };
+        const ignoredKeys = ['studentid'];
+        const filtered = tracer.filterTrace(traceObject, ignoredKeys);
+        const expected = {
+            events: [{
+                resource: {
+                    metadata: { field: { message: 'not-personal' }, nonFiltered: 'studentid' },
+                },
+            }],
+        };
+
+        expect(filtered).to.deep.equal(expected);
+    });
 });
 
 describe('tracer module tests', () => {


### PR DESCRIPTION
Sometimes we add items to metadata as `JSON.stringify`ed strings. we want to filter `ignoredKeys` from these values as well