### PR TITLE
feat(nats): propagate nats id for JSON-based msgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ An environment variable must be added to start tracing the following libraries:
 
 dns: `EPSAGON_DNS_INSTRUMENTATION = true`
 
+NATS: `EPSAGON_PROPAGATE_NATS_ID = TRUE` Propagate Nats Identifier for JSON-based messages.
+
+
 ## Copyright
 
 Provided under the MIT license. See LICENSE for details.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Support for Express, Hapi, and other frameworks is done through [epsagon-framewo
 ## Optional instrumentations
 An environment variable must be added to start tracing the following libraries:
 
-dns: `EPSAGON_DNS_INSTRUMENTATION = true`
+dns: `EPSAGON_DNS_INSTRUMENTATION = TRUE`
 
 NATS: `EPSAGON_PROPAGATE_NATS_ID = TRUE` Propagate Nats Identifier for JSON-based messages.
 

--- a/src/events/nats.js
+++ b/src/events/nats.js
@@ -109,7 +109,9 @@ function wrapNatsPublishFunction(original, serverHostname, jsonConnectProperty) 
             } else if (msgJsonStringify && msgJsonStringify !== NATS_TYPES.badMessage) {
                 responseMetadata.msg = msgJsonStringify;
             }
-            responseMetadata.server_host_name = serverHostname;
+            if (serverHostname) {
+                responseMetadata.server_host_name = serverHostname;
+            }
             const promise = new Promise((resolve) => {
                 patchedCallback = () => {
                     eventInterface.finalizeEvent(


### PR DESCRIPTION
1. add epsagon to nats messages only if: 
   a. process.env.EPSAGON_PROPAGATE_NATS_ID=TRUE
   b. is a JSON based message.
2. update Readme.