### PR TITLE
fix(http.js): fix http response decoding

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -39,6 +39,7 @@ const config = {
     internalSampleRate: 1,
     sendOnlyErrors: (process.env.EPSAGON_SEND_TRACE_ON_ERROR || '').toUpperCase() === 'TRUE',
     sendTimeout: (Number(process.env.EPSAGON_SEND_TIMEOUT_SEC) || DEFAULT_TIMEOUT_SEC) * 1000.0,
+    decodeHTTP: (process.env.EPSAGON_DECODE_HTTP || 'TRUE').toUpperCase() === 'TRUE',
     /**
      * get isEpsagonPatchDisabled
      * @return {boolean} True if DISABLE_EPSAGON or DISABLE_EPSAGON_PATCH are set to TRUE, false
@@ -140,6 +141,11 @@ module.exports.setConfig = function setConfig(configData) {
     // User-defined HTTP minimum status code to be treated as an error.
     if (configData.httpErrorStatusCode) {
         module.exports.HTTP_ERR_CODE = configData.httpErrorStatusCode;
+    }
+
+    // Whether to decode HTTP responses (with gzip, brotli, etc.).
+    if (configData.decodeHTTP === false) {
+        config.decodeHTTP = configData.decodeHTTP;
     }
 
     if (configData.ignoredKeys) {

--- a/src/consts.js
+++ b/src/consts.js
@@ -23,4 +23,6 @@ module.exports.MAX_VALUE_CHARS = 3 * 1024;
 
 module.exports.MAX_LABEL_SIZE = 50 * 1024;
 
+module.exports.MAX_HTTP_VALUE_SIZE = 10 * 1024;
+
 module.exports.MAX_TRACE_SIZE_BYTES = 64 * 1024;

--- a/src/events/http.js
+++ b/src/events/http.js
@@ -277,7 +277,7 @@ function httpWrapper(wrappedFunction) {
 
 
             const responsePromise = new Promise((resolve) => {
-                let data = '';
+                const chunks = [];
 
                 let isTimeout = false;
                 clientRequest.on('timeout', () => {
@@ -305,14 +305,11 @@ function httpWrapper(wrappedFunction) {
                     }
                 });
 
-                clientRequest.on('close', () => {
-                    resolveHttpPromise(httpEvent, resolve, startTime);
-                });
-
                 clientRequest.on('response', (res) => {
-                    res.on('data', (chunk) => { data += chunk; });
+                    res.on('data', (chunk) => { chunks.push(chunk); });
                     res.on('end', () => {
-                        setJsonPayload(httpEvent, 'response_body', data);
+                        setJsonPayload(httpEvent, 'response_body', Buffer.concat(chunks), res.headers['content-encoding']);
+                        resolveHttpPromise(httpEvent, resolve, startTime);
                     });
                 });
             }).catch((err) => {

--- a/src/events/http2.js
+++ b/src/events/http2.js
@@ -68,7 +68,7 @@ function httpWrapper(wrappedFunction, authority) {
             const epsagonTraceId = generateEpsagonTraceId();
             headers['epsagon-trace-id'] = epsagonTraceId; // eslint-disable-line no-param-reassign
 
-            const { slsEvent, eventStartTime } = eventInterface.initializeEvent(
+            const { slsEvent, startTime: eventStartTime } = eventInterface.initializeEvent(
                 'http',
                 hostname,
                 headers[':method'],

--- a/src/helpers/http.js
+++ b/src/helpers/http.js
@@ -28,9 +28,6 @@ const ENCODING_FUNCTIONS = {
     deflate: zlib.deflateSync,
 };
 
-// Whether to try and decode HTTP response
-const DECODE_HTTP = (process.env.EPSAGON_DECODE_HTTP || 'TRUE').toUpperCase() === 'TRUE';
-
 const USER_AGENTS_BLACKLIST = ['openwhisk-client-js'];
 
 /**
@@ -65,7 +62,7 @@ function resolveHttpPromise(httpEvent, resolveFunction, startTime) {
 function setJsonPayload(httpEvent, key, data, encoding) {
     try {
         let jsonData = data;
-        if (DECODE_HTTP && ENCODING_FUNCTIONS[encoding]) {
+        if (config.getConfig().decodeHTTP && ENCODING_FUNCTIONS[encoding]) {
             try {
                 jsonData = ENCODING_FUNCTIONS[encoding](data);
             } catch (err) {

--- a/src/helpers/http.js
+++ b/src/helpers/http.js
@@ -69,7 +69,7 @@ function setJsonPayload(httpEvent, key, data, encoding) {
             try {
                 jsonData = ENCODING_FUNCTIONS[encoding](data);
             } catch (err) {
-                utils.debugLog(`Could not parse ${encoding} ${key} in http`);
+                utils.debugLog(`Could decode ${key} with ${encoding} in http`);
             }
         }
         JSON.parse(jsonData);

--- a/test/unit_tests/test_config.js
+++ b/test/unit_tests/test_config.js
@@ -77,6 +77,11 @@ describe('tracer config tests', () => {
         expect(config.HTTP_ERR_CODE).to.be.equal(httpErrorStatusCode);
     });
 
+    it('setConfig: set decodeHTTP to false', () => {
+        config.setConfig({ decodeHTTP: false });
+        expect(config.getConfig()).to.contain({ decodeHTTP: false });
+    });
+
     it('setConfig: set custom sendTimeout', () => {
         const sendTimeout = 1000;
         config.setConfig({ sendTimeout });


### PR DESCRIPTION
Parsing response data in chucks, and decoding it accordingly (the way `http` handles it).
Decoding will be done by default unless `EPSAGON_DECODE_HTTP !== true`.
In addition, stop relying on request close event, and changing it to response event to terminate the Epsagon event, since it doesn't work for keepalive