### PR TITLE
fix(wsk): fix hanging openwhisk actions

### DIFF
--- a/src/wrappers/openwhisk.js
+++ b/src/wrappers/openwhisk.js
@@ -129,11 +129,11 @@ function baseOpenWhiskWrapper(functionToWrap, options) {
                     eventInterface.setException(runner, err);
                     runnerSendUpdateHandler();
                     throw err;
-                }).finally(() => (
+                }).finally(() => {
                     tracer.sendTrace(runnerSendUpdateHandler).catch(
                         () => {}
-                    ).finally(unregisterTracer)
-                ));
+                    ).finally(unregisterTracer);
+                });
             }
             tracer.sendTrace(runnerSendUpdateHandler).catch(() => {}).finally(unregisterTracer);
             return result;


### PR DESCRIPTION
I don't really understand why, but changing the `finally()` function from returning a value to a block solves our hanging actions problems.....maybe because returning a promise from the finally block makes it hanging but when it's returned into the same scope, it is not? 

maybe something todo with unresolved promises and node 12?