### PR TITLE
fix(typescript-declaration): change labels declaration

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,7 +11,7 @@ declare module 'epsagon' {
     isEpsagonDisabled?: boolean
     urlPatternsToIgnore?: string[]
     ignoredKeys?: string[]
-    labels?: string[]
+    labels?: string[][]
     sendOnlyErrors?: boolean
     sendTimeout?: number
     decodeHTTP?: boolean


### PR DESCRIPTION
On your documentation (https://docs.epsagon.com/docs/nodejs) you are reporting this
epsagon.init({
token: <EPSAGON-TOKEN: string>,
appName: <APP-NAME-STAGE: string>,
labels: [ [, ], ['userID', userID] ]
});

When you are importing the library in a TypeScript project
import epsagon from 'epsagon';

you get this error: Type '[string, string]' is not assignable to type 'string'.

To fix the error and be able to initialize a label we need to change the definition in
labels?: string[][]