### PR TITLE
fix(import-path): fix path

### DIFF
--- a/src/events/dns.js
+++ b/src/events/dns.js
@@ -3,7 +3,7 @@ const utils = require('../utils.js');
 const tracer = require('../tracer.js');
 const moduleUtils = require('./module_utils');
 const eventInterface = require('../event.js');
-const { isBlacklistURL } = require('.././helpers/events');
+const { isBlacklistURL } = require('../helpers/events');
 
 const URL_BLACKLIST = {
     'tc.epsagon.com': 'endsWith',

--- a/src/trace_queue.js
+++ b/src/trace_queue.js
@@ -5,7 +5,7 @@ const EventEmitter = require('events');
 const axios = require('axios');
 const https = require('https');
 const http = require('http');
-const utils = require('../src/utils.js');
+const utils = require('./utils.js');
 const config = require('./config.js');
 
 


### PR DESCRIPTION
I have found 2 paths in the code base that were wrong.

You cannot catch it without upgrading eslint, but every tentative on upgrading libraries fails because nodejs8.x

Many libraries out there dropped the support so unless you drop the support too or you maintain two version:

1. node8x
2. node10/12/14 

you will have this problems and also possible security issues 