### PR TITLE
fix(stepfunction): add two extra methods to track

### DIFF
--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -575,14 +575,18 @@ const stepFunctionsEventCreator = {
      */
     patchInput(request, event) {
         switch (request.operation) {
-        case 'startExecution': {
+        case 'startExecution':
             initializeStepsDict(request, 'input', event);
             break;
-        }
-        case 'sendTaskSuccess': {
+        case 'stopExecution':
+            initializeStepsDict(request, 'input', event);
+            break;
+        case 'sendTaskSuccess':
             initializeStepsDict(request, 'output', event);
             break;
-        }
+        case 'sendTaskFailure':
+            initializeStepsDict(request, 'output', event);
+            break;
         default:
             break;
         }


### PR DESCRIPTION
Add two extra methods:

1. stopExecution
2. sendTaskFailure

Class: AWS.StepFunctions
https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/StepFunctions.html