### PR TITLE
fix(getmetricdata): add cloudwatch getMetricData event

### DIFF
--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -756,7 +756,7 @@ const CloudWatchLogsEventCreator = {
             resource.setName(parameters.logGroupName);
             eventInterface.addToMetadata(event, {
               'aws.cloudwatch.start_time': request.startTime,
-              'aws.cloudwatch.start_time': request.endTime,
+              'aws.cloudwatch.end_time': request.endTime,
             });
             break;
         default:

--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -752,6 +752,13 @@ const CloudWatchLogsEventCreator = {
                 'aws.cloudwatch.start_time': request.startTime,
             });
             break;
+        case 'getMetricData':
+            resource.setName(parameters.logGroupName);
+            eventInterface.addToMetadata(event, {
+              'aws.cloudwatch.start_time': request.startTime,
+              'aws.cloudwatch.start_time': request.endTime,
+            });
+            break;
         default:
             break;
         }

--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -755,8 +755,8 @@ const CloudWatchLogsEventCreator = {
         case 'getMetricData':
             resource.setName(parameters.logGroupName);
             eventInterface.addToMetadata(event, {
-              'aws.cloudwatch.start_time': request.startTime,
-              'aws.cloudwatch.end_time': request.endTime,
+                'aws.cloudwatch.start_time': request.startTime,
+                'aws.cloudwatch.end_time': request.endTime,
             });
             break;
         default:


### PR DESCRIPTION
I have added in the aws event the cloudwatch.getMetricData request
https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CloudWatch.html#getMetricData-property