### PR TITLE
fix(readme-batch): update batch documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,9 +307,13 @@ epsagon.init({
 
 epsagon.wrapBatchJob();
 
-
 function process(params) {
-  // Your code is here
+  try {
+    // your code here
+  } catch (error) {
+    // some other code here
+    process.exitCode = 1; //exits gracefully
+  }
 }
 ```
 


### PR DESCRIPTION
Following the issue https://github.com/epsagon/epsagon-node/issues/455

I have updated the documentation to make it clear how to exit from the batch when an error is caught