### PR TITLE
fix(kinesis): add useful info for kinesis.putRecords trace

### DIFF
--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -179,7 +179,7 @@ const SNSEventCreator = {
 const SQSEventCreator = {
     /**
      * Updates an event with the appropriate fields from a SQS request
-     * @param {object} request The WS.Request object
+     * @param {object} request The AWS.Request object
      * @param {proto.event_pb.Event} event The event to update the data on
      */
     requestHandler(request, event) {

--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -117,6 +117,7 @@ const kinesisEventCreator = {
      */
     responseHandler(response, event) {
         let errorMessages = '';
+        let errorMessagesCount = 0;
         switch (response.request.operation) {
         case 'putRecord':
             eventInterface.addToMetadata(event, {
@@ -125,13 +126,14 @@ const kinesisEventCreator = {
             });
             break;
         case 'putRecords':
-            if (response.data?.FailedRecordCount > 0) {
+            if (response.data.FailedRecordCount && response.data.FailedRecordCount > 0) {
                 errorMessages = JSON.stringify(response.data.Records
                     .map(item => item.ErrorMessage));
+                errorMessagesCount = response.data.FailedRecordCount;
             }
             eventInterface.addToMetadata(event, {
                 total_record_count: `${response.data.Records.length}`,
-                failed_record_count: `${response.data?.FailedRecordCount || 0}`,
+                failed_record_count: `${errorMessagesCount}`,
                 kinesis_error_messages: errorMessages,
             });
             break;

--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -125,13 +125,13 @@ const kinesisEventCreator = {
             });
             break;
         case 'putRecords':
-            if (response.data.FailedRecordCount > 0) {
+            if (response.data?.FailedRecordCount > 0) {
                 errorMessages = JSON.stringify(response.data.Records
                     .map(item => item.ErrorMessage));
             }
             eventInterface.addToMetadata(event, {
                 total_record_count: `${response.data.Records.length}`,
-                failed_record_count: `${response.data.FailedRecordCount}`,
+                failed_record_count: `${response.data?.FailedRecordCount || 0}`,
                 kinesis_error_messages: errorMessages,
             });
             break;

--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -16,13 +16,6 @@ const tryRequire = require('../try_require');
 
 const AWS = tryRequire('aws-sdk');
 
-const AWS_TYPES = {
-    kinesis: {
-        putRecord: 'putRecord',
-        putRecords: 'putRecords',
-    },
-};
-
 const s3EventCreator = {
     /**
      * Updates an event with the appropriate fields from a S3 request
@@ -94,15 +87,26 @@ const kinesisEventCreator = {
      */
     requestHandler(request, event) {
         const parameters = request.params || {};
+        const { operation } = request;
         const resource = event.getResource();
-
-        resource.setName(`${parameters.StreamName}`);
-        if (request.operation !== AWS_TYPES.kinesis.putRecords) {
+        resource.setName(`${parameters.StreamName}` || 'Kinesis');
+        switch (operation) {
+        case 'putRecord':
             eventInterface.addToMetadata(event, {
                 partition_key: `${parameters.PartitionKey}`,
             }, {
                 data: `${parameters.Data}`,
             });
+            break;
+        case 'putRecords':
+            eventInterface.addToMetadata(event, {
+                total_record_count: `${parameters.Records.length}`,
+            }, {
+                data: JSON.stringify(parameters.Records),
+            });
+            break;
+        default:
+            break;
         }
     },
 
@@ -112,18 +116,23 @@ const kinesisEventCreator = {
      * @param {proto.event_pb.Event} event The event to update the data on
      */
     responseHandler(response, event) {
+        let errorMessages = '';
         switch (response.request.operation) {
-        case AWS_TYPES.kinesis.putRecord:
+        case 'putRecord':
             eventInterface.addToMetadata(event, {
                 shard_id: `${response.data.ShardId}`,
                 sequence_number: `${response.data.SequenceNumber}`,
             });
             break;
-        case AWS_TYPES.kinesis.putRecords:
+        case 'putRecords':
+            if (response.data.FailedRecordCount > 0) {
+                errorMessages = JSON.stringify(response.data.Records
+                    .map(item => item.ErrorMessage));
+            }
             eventInterface.addToMetadata(event, {
+                total_record_count: `${response.data.Records.length}`,
                 failed_record_count: `${response.data.FailedRecordCount}`,
-                shard_id: `${response.data.Records[0].ShardId}`,
-                sequence_number: `${response.data.Records[0].SequenceNumber}`,
+                kinesis_error_messages: errorMessages,
             });
             break;
         default:
@@ -170,7 +179,7 @@ const SNSEventCreator = {
 const SQSEventCreator = {
     /**
      * Updates an event with the appropriate fields from a SQS request
-     * @param {object} request The AWS.Request object
+     * @param {object} request The WS.Request object
      * @param {proto.event_pb.Event} event The event to update the data on
      */
     requestHandler(request, event) {

--- a/src/triggers/aws_lambda.js
+++ b/src/triggers/aws_lambda.js
@@ -79,6 +79,7 @@ function createKinesisTrigger(event, trigger) {
         invoke_identity: event.Records[0].invokeIdentityArn,
         sequence_number: event.Records[0].kinesis.sequenceNumber,
         partition_key: event.Records[0].kinesis.partitionKey,
+        total_record_count: event.Records.length,
     });
 }
 


### PR DESCRIPTION
I changed the kinesis.putRecords section.

The request will report total_record_count and will add the payload when config.metadataOnly = false

In the response instead:
I removed shard_id and sequence_number because was picking up only the first and it is wrong in the PutRecords but I added:
total_record_count
kinesis_error_messages only if failed_record_count > 0