### PR TITLE
fix(wsk): revert finally changes of #428

### DIFF
--- a/src/wrappers/openwhisk.js
+++ b/src/wrappers/openwhisk.js
@@ -129,11 +129,11 @@ function baseOpenWhiskWrapper(functionToWrap, options) {
                     eventInterface.setException(runner, err);
                     runnerSendUpdateHandler();
                     throw err;
-                }).finally(() => {
+                }).finally(() => (
                     tracer.sendTrace(runnerSendUpdateHandler).catch(
                         () => {}
-                    ).finally(unregisterTracer);
-                });
+                    ).finally(unregisterTracer)
+                ));
             }
             tracer.sendTrace(runnerSendUpdateHandler).catch(() => {}).finally(unregisterTracer);
             return result;


### PR DESCRIPTION
The changes from #428 causes the traces not being sent, as the action is terminated earlier.
I think it's better to revert the change and investigate again, which actions really hang.
