### PR TITLE
fix(dynamodb-stream): add DynamoDB stream as additional data only when metadaOnly is false

### DIFF
--- a/src/triggers/aws_lambda.js
+++ b/src/triggers/aws_lambda.js
@@ -255,6 +255,7 @@ function createDynamoDBTrigger(event, trigger) {
         region: record.awsRegion,
         sequence_number: record.dynamodb.SequenceNumber,
         item_hash: itemHash,
+        total_record_count: event.Records.length,
     }, {
         data: JSON.stringify(event.Records),
     });

--- a/src/triggers/aws_lambda.js
+++ b/src/triggers/aws_lambda.js
@@ -255,6 +255,8 @@ function createDynamoDBTrigger(event, trigger) {
         region: record.awsRegion,
         sequence_number: record.dynamodb.SequenceNumber,
         item_hash: itemHash,
+    }, {
+        data: JSON.stringify(event.Records),
     });
 }
 


### PR DESCRIPTION
When DynamoDB stream is the input of a Lambda it is nice to see the data if the flag metadataOnly is false