### PR TITLE
fix(sqs): add total_record_count in SQS trigger lambda

### DIFF
--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -203,11 +203,37 @@ const SQSEventCreator = {
      * @param {proto.event_pb.Event} event The event to update the data on
      */
     responseHandler(response, event) {
+        let errorMessages = '';
+        let errorMessagesCount = 0;
         switch (response.request.operation) {
         case 'sendMessage':
             eventInterface.addToMetadata(event, {
                 'Message ID': `${response.data.MessageId}`,
                 'MD5 Of Message Body': `${response.data.MD5OfMessageBody}`,
+            });
+            break;
+        case 'sendMessageBatch':
+            if (response.data.Failed && response.data.Failed > 0) {
+                errorMessages = JSON.stringify(response.data.Failed
+                    .map(item => item));
+                errorMessagesCount = response.data.FailedRecordCount;
+            }
+            eventInterface.addToMetadata(event, {
+                successful_record_count: `${response.data.Successful.length}`,
+                failed_record_count: `${errorMessagesCount}`,
+                sqs_error_messages: errorMessages,
+            });
+            break;
+        case 'deleteMessageBatch':
+            if (response.data.Failed && response.data.Failed > 0) {
+                errorMessages = JSON.stringify(response.data.Failed
+                    .map(item => item));
+                errorMessagesCount = response.data.FailedRecordCount;
+            }
+            eventInterface.addToMetadata(event, {
+                successful_record_count: `${response.data.Successful.length}`,
+                failed_record_count: `${errorMessagesCount}`,
+                sqs_error_messages: errorMessages,
             });
             break;
         case 'receiveMessage': {

--- a/src/triggers/aws_lambda.js
+++ b/src/triggers/aws_lambda.js
@@ -125,6 +125,7 @@ function createSQSTrigger(event, trigger) {
             }
             return record;
         }),
+        total_record_count: event.Records.length,
     });
     try {
         const messageBody = JSON.parse(sqsMessageBody);


### PR DESCRIPTION
Because SQS as trigger now could have a configuration like
Batch size: 10000
Batch window: 300

the trace in the lambda will report
aws.lambda.is_trimmed: true

and even increasing EPSAGON_MAX_TRACE_SIZE will not help so it would be useful to know how many records are processed from the Lambda

I have also added more info for 2 operations:
sendMessageBatch
deleteMessageBatch

I think is useful to see:

1. successful_record_count
2. failed_record_count
3. sqs_error_messages


the API sendMessageBatch and  deleteMessageBatch are pretty much the same

```
export type BatchResultErrorEntryList = BatchResultErrorEntry[];
export type SendMessageBatchResultEntryList = SendMessageBatchResultEntry[];
export interface SendMessageBatchResult {
    /**
     * A list of  SendMessageBatchResultEntry  items.
     */
    Successful: SendMessageBatchResultEntryList;
    /**
     * A list of  BatchResultErrorEntry  items with error details about each message that can't be enqueued.
     */
    Failed: BatchResultErrorEntryList;
  }

export interface BatchResultErrorEntry {
    /**
     * The Id of an entry in a batch request.
     */
    Id: String;
    /**
     * Specifies whether the error happened due to the caller of the batch API action.
     */
    SenderFault: Boolean;
    /**
     * An error code representing why the action failed on this entry.
     */
    Code: String;
    /**
     * A message explaining why the action failed on this entry.
     */
    Message?: String;
  }
```

```
 export type DeleteMessageBatchResultEntryList = DeleteMessageBatchResultEntry[];
 export type BatchResultErrorEntryList = BatchResultErrorEntry[];
 export interface DeleteMessageBatchResult {
    /**
     * A list of  DeleteMessageBatchResultEntry  items.
     */
    Successful: DeleteMessageBatchResultEntryList;
    /**
     * A list of  BatchResultErrorEntry  items.
     */
    Failed: BatchResultErrorEntryList;
  }

export interface BatchResultErrorEntry {
    /**
     * The Id of an entry in a batch request.
     */
    Id: String;
    /**
     * Specifies whether the error happened due to the caller of the batch API action.
     */
    SenderFault: Boolean;
    /**
     * An error code representing why the action failed on this entry.
     */
    Code: String;
    /**
     * A message explaining why the action failed on this entry.
     */
    Message?: String;
  }
```