### PR TITLE
fix(performance): Require specific aws-sdk modules

### DIFF
--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -14,7 +14,7 @@ const resourceUtils = require('../resource_utils/sqs_utils.js');
 const moduleUtils = require('./module_utils');
 const tryRequire = require('../try_require');
 
-const AWS = tryRequire('aws-sdk');
+const DynamoDB = tryRequire('aws-sdk/clients/dynamodb');
 
 const s3EventCreator = {
     /**
@@ -345,7 +345,7 @@ const dynamoDBEventCreator = {
      * @return {string} The hash of the item
      */
     generateItemHash(item) {
-        const unmarshalledItem = AWS.DynamoDB.Converter.unmarshall(item);
+        const unmarshalledItem = DynamoDB.Converter.unmarshall(item);
         return md5(JSON.sortify(unmarshalledItem));
     },
 
@@ -1001,7 +1001,7 @@ function wrapPromiseOnAdd(wrappedFunction) {
             // it is OK to just re-wrap, as the original function overrides
             // `promise` anyway
             moduleUtils.patchModule(
-                'aws-sdk',
+                'aws-sdk/global',
                 'promise',
                 AWSSDKWrapper,
                 AWSmod => AWSmod.Request.prototype
@@ -1019,13 +1019,13 @@ module.exports = {
      */
     init() {
         moduleUtils.patchModule(
-            'aws-sdk',
+            'aws-sdk/global',
             'send',
             AWSSDKWrapper,
             AWSmod => AWSmod.Request.prototype
         );
         moduleUtils.patchModule(
-            'aws-sdk',
+            'aws-sdk/global',
             'promise',
             AWSSDKWrapper,
             AWSmod => AWSmod.Request.prototype
@@ -1033,7 +1033,7 @@ module.exports = {
 
         // This method is static - not in prototype
         moduleUtils.patchModule(
-            'aws-sdk',
+            'aws-sdk/global',
             'addPromisesToClass',
             wrapPromiseOnAdd,
             AWSmod => AWSmod.Request

--- a/src/events/winston_cloudwatch.js
+++ b/src/events/winston_cloudwatch.js
@@ -3,7 +3,8 @@ const utils = require('../utils');
 const tracer = require('../tracer');
 const tryRequire = require('../try_require');
 
-const AWS = tryRequire('aws-sdk');
+const AWS = tryRequire('aws-sdk/global');
+const STS = tryRequire('aws-sdk/clients/sts');
 
 const logDestinations = [];
 
@@ -21,7 +22,7 @@ function loadAWSLogDestination(options) {
     const destination = {};
     destination.log_group_name = options.logGroupName;
     destination.log_stream_name = options.logStreamName;
-    const sts = new AWS.STS();
+    const sts = new STS();
     const cwConfig = (options.cloudWatchLogs && options.cloudWatchLogs.config) || {};
     destination.region = (
         options.awsRegion ||

--- a/src/patcher.js
+++ b/src/patcher.js
@@ -33,7 +33,7 @@ const fs = require('./events/fs.js');
 
 
 const LIBNAME_TO_PATCHER = {
-    'aws-sdk': awsSDKPatcher,
+    'aws-sdk/global': awsSDKPatcher,
     'azure-sdk': azureSdkPatcher,
     'winston-cw': winstonCloudwatchPatcher,
     http: httpPatcher,

--- a/src/triggers/aws_lambda.js
+++ b/src/triggers/aws_lambda.js
@@ -12,7 +12,7 @@ const utils = require('../utils');
 const resourceUtils = require('../resource_utils/sqs_utils.js');
 const config = require('../config.js');
 
-const AWS = tryRequire('aws-sdk');
+const DynamoDB = tryRequire('aws-sdk/clients/dynamodb');
 
 /**
  * Fills the common fields for a trigger event
@@ -264,12 +264,12 @@ function createDynamoDBTrigger(event, trigger) {
     const resource = trigger.getResource();
     const record = event.Records[0];
     let itemHash = '';
-    if (AWS) {
+    if (DynamoDB) {
         // in case of a delete - hash only the key.
         const item = (
             record.eventName === 'REMOVE' ?
-                AWS.DynamoDB.Converter.unmarshall(record.dynamodb.Keys) :
-                AWS.DynamoDB.Converter.unmarshall(record.dynamodb.NewImage)
+                DynamoDB.Converter.unmarshall(record.dynamodb.Keys) :
+                DynamoDB.Converter.unmarshall(record.dynamodb.NewImage)
         );
         itemHash = md5(JSON.sortify(item));
     }

--- a/test/acceptance/acceptance.js
+++ b/test/acceptance/acceptance.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const { expect } = require('chai');
-const AWS = require('aws-sdk');
+const Lambda = require('aws-sdk/clients/lambda');
 
 chai.use(chaiAsPromised);
 
@@ -17,7 +17,7 @@ const RUNTIME = process.env.RUNTIME || 'nodejs8.10';
  * @returns {hash} The functions output
  */
 function invoke(name, payload) {
-    const lambda = new AWS.Lambda({ region: 'us-east-2' });
+    const lambda = new Lambda({ region: 'us-east-2' });
     const params = {
         FunctionName: SERVICE_PREFIX + name,
         Payload: JSON.stringify(payload),


### PR DESCRIPTION
#### Issue
Requiring the entire `aws-sdk` seem to have noticeable performance penalty.  

#### Solution
Instead, require the global instance from `aws-sdk/global` or the needed client from `aws-sdk/clients/xxx`