### PR TITLE
fix(dynamo-batchWriteItem): add unprocessedItems_count to batchWriteItem

### DIFF
--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -505,10 +505,12 @@ const dynamoDBEventCreator = {
         }
 
         case 'batchWriteItem': {
-            const unprocessedItems = (Object.keys(response.data.UnprocessedItems));
-            eventInterface.addToMetadata(event, {
-                unprocessedItems_count: unprocessedItems.length,
-            });
+            if (response.data.UnprocessedItems) {
+                const unprocessedItems = (Object.keys(response.data.UnprocessedItems));
+                eventInterface.addToMetadata(event, {
+                    unprocessedItems_count: unprocessedItems.length,
+                });
+            }
             break;
         }
 

--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -504,6 +504,14 @@ const dynamoDBEventCreator = {
             break;
         }
 
+        case 'batchWriteItem': {
+            const unprocessedItems = (Object.keys(response.data.UnprocessedItems));
+            eventInterface.addToMetadata(event, {
+                unprocessedItems_count: unprocessedItems.length,
+            });
+            break;
+        }
+
         default:
             break;
         }


### PR DESCRIPTION
Hello,

I have noticed that the operation from DynamoDB BatchWriteItem do not show if we have UnprocessedItems.

I have added to the response metadata unprocessedItems_count property that should show the count.
It is useful just as a reference in case of debugging missing records. 

The aws-sdk interface report:

> /**
     * A map of tables and requests against those tables that were not processed. The UnprocessedItems value is in the same form as RequestItems, so you can provide this value directly to a subsequent BatchGetItem operation. For more information, see RequestItems in the Request Parameters section. Each UnprocessedItems entry consists of a table name and, for that table, a list of operations to perform (DeleteRequest or PutRequest).    DeleteRequest - Perform a DeleteItem operation on the specified item. The item to be deleted is identified by a Key subelement:    Key - A map of primary key attribute values that uniquely identify the item. Each entry in this map consists of an attribute name and an attribute value.      PutRequest - Perform a PutItem operation on the specified item. The item to be put is identified by an Item subelement:    Item - A map of attributes and their values. Each entry in this map consists of an attribute name and an attribute value. Attribute values must not be null; string and binary type attributes must have lengths greater than zero; and set type attributes must not be empty. Requests that contain empty values will be rejected with a ValidationException exception. If you specify any attributes that are part of an index key, then the data types for those attributes must match those of the schema in the table's attribute definition.     If there are no unprocessed items remaining, the response contains an empty UnprocessedItems map.
     */
    UnprocessedItems?: BatchWriteItemRequestMap;