### PR TITLE
fix(protobuf): use probobuf minified

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4549,9 +4549,9 @@
       }
     },
     "google-protobuf-minified": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/google-protobuf-minified/-/google-protobuf-minified-1.0.4.tgz",
-      "integrity": "sha512-AkzvypasF9K2auzRzru84O73ywFqfIIRa8+wWA3GJsB0WliPjKbfn96Hs1XgxO0PByUIXTj58F9BFpMWLqrA0Q=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/google-protobuf-minified/-/google-protobuf-minified-1.0.5.tgz",
+      "integrity": "sha512-nLTrnN5XzNIZgU/ULYisRAcsNyN/e2Iswi5ziMGEL7XPlLXum/groucsnOlFkEU8u9j8TnI2l4FlEoH0dEHhyQ=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4548,10 +4548,10 @@
         }
       }
     },
-    "google-protobuf": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.6.1.tgz",
-      "integrity": "sha512-SJYemeX5GjDLPnadcmCNQePQHCS4Hl5fOcI/JawqDIYFhCmrtYAjcx/oTQx/Wi8UuCuZQhfvftbmPePPAYHFtA=="
+    "google-protobuf-minified": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf-minified/-/google-protobuf-minified-1.0.4.tgz",
+      "integrity": "sha512-AkzvypasF9K2auzRzru84O73ywFqfIIRa8+wWA3GJsB0WliPjKbfn96Hs1XgxO0PByUIXTj58F9BFpMWLqrA0Q=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2041,12 +2041,19 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
     },
-    "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+    "axios-minified": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/axios-minified/-/axios-minified-1.0.2.tgz",
+      "integrity": "sha512-qbfUi4bWPDNfX1F6SHbbRjXfL1VUC0DlS6IsT6Sge0iXLZXrSlSEWyhR5YXhUHmOrKOBTHuahXpAGh36htGRwg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+          "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+        }
       }
     },
     "axobject-query": {
@@ -4230,11 +4237,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
-      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
     },
     "foreground-child": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
-    "google-protobuf-minified": "^1.0.4",
+    "google-protobuf-minified": "^1.0.5",
     "json-stringify-safe": "^5.0.1",
     "json.sortify": "^2.2.2",
     "md5": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "underscore": "^1.12.0"
   },
   "dependencies": {
-    "axios": "^0.21.1",
+    "axios-minified": "^1.0.2",
     "google-protobuf-minified": "^1.0.5",
     "json-stringify-safe": "^5.0.1",
     "json.sortify": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "axios-minified": "^1.0.2",
-    "google-protobuf-minified": "^1.0.5",
+    "google-protobuf-minified": "^1.0.8",
     "json-stringify-safe": "^5.0.1",
     "json.sortify": "^2.2.2",
     "md5": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
-    "google-protobuf": "^3.5.0",
+    "google-protobuf-minified": "^1.0.4",
     "json-stringify-safe": "^5.0.1",
     "json.sortify": "^2.2.2",
     "md5": "^2.2.1",

--- a/src/containers/azure.js
+++ b/src/containers/azure.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+const axios = require('axios-minified');
 const utils = require('../utils');
 const eventIterface = require('../event');
 

--- a/src/containers/ec2.js
+++ b/src/containers/ec2.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+const axios = require('axios-minified');
 const utils = require('../utils');
 const eventIterface = require('../event');
 

--- a/src/containers/ecs.js
+++ b/src/containers/ecs.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+const axios = require('axios-minified');
 const utils = require('../utils');
 const eventInterface = require('../event');
 

--- a/src/proto/error_code_pb.js
+++ b/src/proto/error_code_pb.js
@@ -7,7 +7,7 @@
  */
 // GENERATED CODE -- DO NOT EDIT!
 
-var jspb = require('google-protobuf');
+var jspb = require('google-protobuf-minified');
 var goog = jspb;
 var global = Function('return this')();
 

--- a/src/proto/event_pb.js
+++ b/src/proto/event_pb.js
@@ -7,7 +7,7 @@
  */
 // GENERATED CODE -- DO NOT EDIT!
 
-var jspb = require('google-protobuf');
+var jspb = require('google-protobuf-minified');
 var goog = jspb;
 var global = Function('return this')();
 

--- a/src/proto/exception_pb.js
+++ b/src/proto/exception_pb.js
@@ -7,7 +7,7 @@
  */
 // GENERATED CODE -- DO NOT EDIT!
 
-var jspb = require('google-protobuf');
+var jspb = require('google-protobuf-minified');
 var goog = jspb;
 var global = Function('return this')();
 

--- a/src/proto/timestamp_pb.js
+++ b/src/proto/timestamp_pb.js
@@ -7,7 +7,7 @@
  */
 // GENERATED CODE -- DO NOT EDIT!
 
-var jspb = require('google-protobuf');
+var jspb = require('google-protobuf-minified');
 var goog = jspb;
 var global = Function('return this')();
 

--- a/src/proto/trace_pb.js
+++ b/src/proto/trace_pb.js
@@ -7,7 +7,7 @@
  */
 // GENERATED CODE -- DO NOT EDIT!
 
-var jspb = require('google-protobuf');
+var jspb = require('google-protobuf-minified');
 var goog = jspb;
 var global = Function('return this')();
 

--- a/src/runners/aws_batch.js
+++ b/src/runners/aws_batch.js
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Runner for AWS Batch environment
  */
-const axios = require('axios');
+const axios = require('axios-minified');
 const serverlessEvent = require('../proto/event_pb.js');
 const eventInterface = require('../event.js');
 const errorCode = require('../proto/error_code_pb.js');

--- a/src/trace_queue.js
+++ b/src/trace_queue.js
@@ -2,7 +2,7 @@
  * @fileoverview The traces queue, cunsume traces and sends in batches
  */
 const EventEmitter = require('events');
-const axios = require('axios');
+const axios = require('axios-minified');
 const https = require('https');
 const http = require('http');
 const utils = require('./utils.js');

--- a/src/trace_senders/http.js
+++ b/src/trace_senders/http.js
@@ -2,7 +2,7 @@
  * @fileoverview Send traces to the epsagon backend using http
  */
 
-const axios = require('axios');
+const axios = require('axios-minified');
 const http = require('http');
 const https = require('https');
 const utils = require('../utils.js');

--- a/test/unit_tests/runners/test_aws_batch.js
+++ b/test/unit_tests/runners/test_aws_batch.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
-const axios = require('axios');
+const axios = require('axios-minified');
 const batchRunner = require('../../../src/runners/aws_batch.js');
 const errorCode = require('../../../src/proto/error_code_pb.js');
 const tracer = require('../../../src/tracer.js');


### PR DESCRIPTION
use the dependency "google-protobuf-minified" instead of the regular "google-protobuf".

The "google-protobuf-minified" is a minified version we created from google-protobuf. it can be found here: https://www.npmjs.com/package/google-protobuf-minified
(it is on my personal un-paid user). 

In order to test the code I did the following:
1. run test/unit_tests/**/*.js using mocha
2. run a specific test which created a trace, and saw it on epsagon. 