### PR TITLE
feat(lambda-params): add lambda params on invoke

### DIFF
--- a/src/events/aws_sdk.js
+++ b/src/events/aws_sdk.js
@@ -983,13 +983,16 @@ function AWSSDKWrapper(wrappedFunction) {
                 request.service.constructor.prototype
             );
 
+            const resourceName = request.params ? request.params.FunctionName : 'lambda';
+            const requestPayload = request.params ? request.params.Payload : '';
+
             if (!(serviceIdentifier in specificEventCreators)) {
                 // resource is not supported yet
                 return wrappedFunction.apply(this, [callback]);
             }
 
             const resource = new serverlessEvent.Resource([
-                '',
+                resourceName,
                 serviceIdentifier,
                 `${request.operation}`,
             ]);
@@ -1005,6 +1008,7 @@ function AWSSDKWrapper(wrappedFunction) {
             ]);
 
             awsEvent.setResource(resource);
+            eventInterface.addToMetadata(awsEvent, { payload: requestPayload });
 
             if ('patchInput' in specificEventCreators[serviceIdentifier]) {
                 specificEventCreators[serviceIdentifier].patchInput(this, awsEvent);


### PR DESCRIPTION
when lambda is invoked we want to trace its data regardless if invoke succeded or not