### PR TITLE
fix(mem-leak): skip return value

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -56,6 +56,7 @@ const config = {
     token: process.env.EPSAGON_TOKEN || '',
     appName: process.env.EPSAGON_APP_NAME || 'Application',
     metadataOnly: (process.env.EPSAGON_METADATA || '').toUpperCase() === 'TRUE',
+    skipReturnVal: (process.env.EPSAGON_SKIP_RETURN_VALUE || '').toLocaleUpperCase === 'TRUE',
     useSSL: (process.env.EPSAGON_SSL || 'TRUE').toUpperCase() === 'TRUE',
     traceCollectorURL: process.env.EPSAGON_COLLECTOR_URL || consts.TRACE_COLLECTOR_URL,
     isEpsagonDisabled: (process.env.DISABLE_EPSAGON || '').toUpperCase() === 'TRUE',
@@ -157,6 +158,10 @@ module.exports.setConfig = function setConfig(configData) {
 
     if (configData.isEpsagonDisabled) {
         config.isEpsagonDisabled = configData.isEpsagonDisabled;
+    }
+
+    if (configData.skipReturnVal) {
+        config.skipReturnVal = configData.skipReturnVal;
     }
 
     if (configData.appName) {

--- a/src/config.js
+++ b/src/config.js
@@ -56,7 +56,6 @@ const config = {
     token: process.env.EPSAGON_TOKEN || '',
     appName: process.env.EPSAGON_APP_NAME || 'Application',
     metadataOnly: (process.env.EPSAGON_METADATA || '').toUpperCase() === 'TRUE',
-    skipReturnValue: (process.env.EPSAGON_SKIP_RETURN_VALUE || '').toUpperCase() === 'TRUE',
     useSSL: (process.env.EPSAGON_SSL || 'TRUE').toUpperCase() === 'TRUE',
     traceCollectorURL: process.env.EPSAGON_COLLECTOR_URL || consts.TRACE_COLLECTOR_URL,
     isEpsagonDisabled: (process.env.DISABLE_EPSAGON || '').toUpperCase() === 'TRUE',
@@ -129,6 +128,9 @@ if ((process.env.EPSAGON_SSL || 'TRUE').toUpperCase() === 'TRUE') {
     config.traceCollectorURL = config.traceCollectorURL.replace('http:', 'https:');
 }
 
+const skipReturnValue = (process.env.EPSAGON_SKIP_RETURN_VALUE || '').toUpperCase() === 'TRUE';
+config.addReturnValue = !skipReturnValue;
+
 if (process.env.EPSAGON_PATCH_WHITELIST) {
     config.patchWhitelist = process.env.EPSAGON_PATCH_WHITELIST.split(',');
 }
@@ -160,8 +162,9 @@ module.exports.setConfig = function setConfig(configData) {
         config.isEpsagonDisabled = configData.isEpsagonDisabled;
     }
 
-    if (configData.skipReturnValue) {
-        config.skipReturnValue = configData.skipReturnValue;
+    // Set addReturnValue for lambda
+    if (configData.addReturnValue || configData.addReturnValue === false) {
+        config.addReturnValue = configData.addReturnValue;
     }
 
     if (configData.appName) {

--- a/src/config.js
+++ b/src/config.js
@@ -56,7 +56,7 @@ const config = {
     token: process.env.EPSAGON_TOKEN || '',
     appName: process.env.EPSAGON_APP_NAME || 'Application',
     metadataOnly: (process.env.EPSAGON_METADATA || '').toUpperCase() === 'TRUE',
-    skipReturnVal: (process.env.EPSAGON_SKIP_RETURN_VALUE || '').toLocaleUpperCase === 'TRUE',
+    skipReturnValue: (process.env.EPSAGON_SKIP_RETURN_VALUE || '').toUpperCase === 'TRUE',
     useSSL: (process.env.EPSAGON_SSL || 'TRUE').toUpperCase() === 'TRUE',
     traceCollectorURL: process.env.EPSAGON_COLLECTOR_URL || consts.TRACE_COLLECTOR_URL,
     isEpsagonDisabled: (process.env.DISABLE_EPSAGON || '').toUpperCase() === 'TRUE',
@@ -160,8 +160,8 @@ module.exports.setConfig = function setConfig(configData) {
         config.isEpsagonDisabled = configData.isEpsagonDisabled;
     }
 
-    if (configData.skipReturnVal) {
-        config.skipReturnVal = configData.skipReturnVal;
+    if (configData.skipReturnValue) {
+        config.skipReturnValue = configData.skipReturnValue;
     }
 
     if (configData.appName) {

--- a/src/config.js
+++ b/src/config.js
@@ -56,7 +56,7 @@ const config = {
     token: process.env.EPSAGON_TOKEN || '',
     appName: process.env.EPSAGON_APP_NAME || 'Application',
     metadataOnly: (process.env.EPSAGON_METADATA || '').toUpperCase() === 'TRUE',
-    skipReturnValue: (process.env.EPSAGON_SKIP_RETURN_VALUE || '').toUpperCase === 'TRUE',
+    skipReturnValue: (process.env.EPSAGON_SKIP_RETURN_VALUE || '').toUpperCase() === 'TRUE',
     useSSL: (process.env.EPSAGON_SSL || 'TRUE').toUpperCase() === 'TRUE',
     traceCollectorURL: process.env.EPSAGON_COLLECTOR_URL || consts.TRACE_COLLECTOR_URL,
     isEpsagonDisabled: (process.env.DISABLE_EPSAGON || '').toUpperCase() === 'TRUE',

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,7 @@ declare module 'epsagon' {
     sendOnlyErrors?: boolean
     sendTimeout?: number
     decodeHTTP?: boolean
+    skipReturnValue?: boolean
     disableHttpResponseBodyCapture?: boolean
     loggingTracingEnabled?: boolean
     sendBatch?: boolean

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,7 +16,6 @@ declare module 'epsagon' {
     sendOnlyErrors?: boolean
     sendTimeout?: number
     decodeHTTP?: boolean
-    skipReturnValue?: boolean
     disableHttpResponseBodyCapture?: boolean
     loggingTracingEnabled?: boolean
     sendBatch?: boolean

--- a/src/utils.js
+++ b/src/utils.js
@@ -183,19 +183,6 @@ const getLastSplittedItem = (string, seperator) => {
 const isLambdaEnv = !!process.env.AWS_LAMBDA_FUNCTION_NAME;
 
 /**
- * Get target trace object from runner
- * @param {runner} runner proto.event_pb.Event runner representing the lambda
- * @returns {string} the name of the object lambda was triggered with
- */
-const getObjectFromRunner = (runner) => {
-    const { array } = runner;
-    if (array && array.length >= 2 && array[2][0]) {
-        return array[2][0];
-    }
-    return '';
-};
-
-/**
  * Function to truncate a long string to a maximum length.
  * @param {string} message to be trancated.
  * @param {integer} maxSize maximum message length.
@@ -228,7 +215,6 @@ module.exports.printError = printError;
 module.exports.makeQueryablePromise = makeQueryablePromise;
 module.exports.flatten = flatten;
 module.exports.getLastSplittedItem = getLastSplittedItem;
-module.exports.getObjectFromRunner = getObjectFromRunner;
 module.exports.isPromise = isPromise;
 module.exports.isLambdaEnv = isLambdaEnv;
 module.exports.getValueIfExist = getValueIfExist;

--- a/src/wrappers/lambda.js
+++ b/src/wrappers/lambda.js
@@ -191,7 +191,7 @@ function baseLambdaWrapper(
                 eventInterface.addToMetadata(runner, { status_code: statusCode });
             }
             const config = getConfig();
-            if (error === null && !config.metadataOnly && !config.skipReturnVal) {
+            if (error === null && !config.metadataOnly && !config.skipReturnValue) {
                 try {
                     // Taken from AWS Lambda runtime
                     const jsonResult = JSON.stringify(

--- a/src/wrappers/lambda.js
+++ b/src/wrappers/lambda.js
@@ -191,7 +191,7 @@ function baseLambdaWrapper(
                 eventInterface.addToMetadata(runner, { status_code: statusCode });
             }
             const config = getConfig();
-            if (error === null && !config.metadataOnly && !config.skipReturnValue) {
+            if (error === null && !config.metadataOnly && config.addReturnValue) {
                 try {
                     // Taken from AWS Lambda runtime
                     const jsonResult = JSON.stringify(

--- a/src/wrappers/lambda.js
+++ b/src/wrappers/lambda.js
@@ -190,11 +190,8 @@ function baseLambdaWrapper(
             if (statusCode) {
                 eventInterface.addToMetadata(runner, { status_code: statusCode });
             }
-
-            const table = utils.getObjectFromRunner(runner);
             const config = getConfig();
-
-            if (error === null && !config.metadataOnly && !config.ignoredDBTables.includes(table)) {
+            if (error === null && !config.metadataOnly && !config.skipReturnVal) {
                 try {
                     // Taken from AWS Lambda runtime
                     const jsonResult = JSON.stringify(

--- a/test/unit_tests/test_config.js
+++ b/test/unit_tests/test_config.js
@@ -102,9 +102,14 @@ describe('tracer config tests', () => {
         expect(config.getConfig()).to.contain({ decodeHTTP: false });
     });
 
-    it('setConfig: set skipReturnValue to true', () => {
-        config.setConfig({ skipReturnValue: false });
-        expect(config.getConfig()).to.contain({ skipReturnValue: false });
+    it('setConfig: set addReturnValue to false', () => {
+        config.setConfig({ addReturnValue: false });
+        expect(config.getConfig()).to.contain({ addReturnValue: false });
+    });
+
+    it('setConfig: set addReturnValue to true', () => {
+        config.setConfig({ addReturnValue: true });
+        expect(config.getConfig()).to.contain({ addReturnValue: true });
     });
 
     it('setConfig: set custom sendTimeout', () => {

--- a/test/unit_tests/test_config.js
+++ b/test/unit_tests/test_config.js
@@ -102,6 +102,11 @@ describe('tracer config tests', () => {
         expect(config.getConfig()).to.contain({ decodeHTTP: false });
     });
 
+    it('setConfig: set skipReturnValue to true', () => {
+        config.setConfig({ skipReturnValue: true });
+        expect(config.getConfig()).to.contain({ skipReturnValue: true });
+    });
+
     it('setConfig: set custom sendTimeout', () => {
         const sendTimeout = 1000;
         config.setConfig({ sendTimeout });

--- a/test/unit_tests/test_config.js
+++ b/test/unit_tests/test_config.js
@@ -103,8 +103,8 @@ describe('tracer config tests', () => {
     });
 
     it('setConfig: set skipReturnValue to true', () => {
-        config.setConfig({ skipReturnValue: true });
-        expect(config.getConfig()).to.contain({ skipReturnValue: true });
+        config.setConfig({ skipReturnValue: false });
+        expect(config.getConfig()).to.contain({ skipReturnValue: false });
     });
 
     it('setConfig: set custom sendTimeout', () => {

--- a/test/unit_tests/wrappers/test_lambda.js
+++ b/test/unit_tests/wrappers/test_lambda.js
@@ -512,6 +512,18 @@ describe('lambdaWrapper tests', () => {
         }, 1);
     });
 
+    it('lambdaWrapper: omit return value by env variable', (done) => {
+        config.setConfig({ addReturnValue: false });
+        this.wrappedStub({}, this.context, this.callbackStub);
+        expect(this.createFromEventStub.callCount).to.equal(1);
+        expect(getReturnValue(this.addRunnerStub)).to.equal(undefined);
+        expect(this.addExceptionStub.called).to.be.false;
+        expect(this.callbackStub.callCount).to.equal(0);
+        expect(this.setExceptionStub.called).to.be.false;
+        config.setConfig({ addReturnValue: true });
+        done();
+    });
+
     it('lambdaWrapper: dont trace ignored payloads (multiple)', (done) => {
         process.env.EPSAGON_PAYLOADS_TO_IGNORE = '[{"source": "serverless-plugin-warmup"}, {"foo": "bar"}]';
 


### PR DESCRIPTION
Following memory leak issue -> CS-167 setting a more basic broad solution. Setting EPSAGON_SKIP_RETURN_VALUE to true will prevent lambda wrapper from documenting DB return value (which potentially can increase lambda's container memory usage)